### PR TITLE
Improve error handling and debugging

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - RxSwift (5.0.0)
+
+DEPENDENCIES:
+  - RxSwift
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - RxSwift
+
+SPEC CHECKSUMS:
+  RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
+
+PODFILE CHECKSUM: 5551296701d378043c3389695fdd18bdc60a351d
+
+COCOAPODS: 1.7.5

--- a/Sources/RxTinyNetworking/RxTinyNetworking.swift
+++ b/Sources/RxTinyNetworking/RxTinyNetworking.swift
@@ -24,7 +24,7 @@ public extension Reactive where Base: TinyNetworkingType {
                 case let .failure(error):
                     single(.error(error))
                 case let .success(response):
-                    single(.success(Response(urlRequest: response.urlRequest, data: response.data)))
+                    single(.success(response))
                 }
             }
 

--- a/Sources/TinyNetworking/Combine/TinyNetworking+Combine.swift
+++ b/Sources/TinyNetworking/Combine/TinyNetworking+Combine.swift
@@ -16,7 +16,7 @@ public extension TinyNetworking {
         resource: R,
         session: TinyNetworkingSession = URLSession.shared,
         queue: DispatchQueue = .main
-        ) -> AnyPublisher<Response, Error> {
+        ) -> AnyPublisher<Response, TinyNetworkingError> {
         let publisher = TinyNetworkingPublisher<Response> { [weak self] subscriber in
             return self?.request(
                 resource: resource,

--- a/Sources/TinyNetworking/Combine/TinyNetworkingPublisher.swift
+++ b/Sources/TinyNetworking/Combine/TinyNetworkingPublisher.swift
@@ -11,11 +11,11 @@ import Combine
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 internal class TinyNetworkingPublisher<Output>: Publisher {
-    typealias Failure = Error
+    typealias Failure = TinyNetworkingError
 
-    private let callback: (AnySubscriber<Output, Error>) -> URLSessionDataTask?
+    private let callback: (AnySubscriber<Output, Failure>) -> URLSessionDataTask?
 
-    init(callback: @escaping (AnySubscriber<Output, Error>) -> URLSessionDataTask?) {
+    init(callback: @escaping (AnySubscriber<Output, Failure>) -> URLSessionDataTask?) {
         self.callback = callback
     }
 
@@ -31,7 +31,7 @@ private extension TinyNetworkingPublisher {
 
         private let dataTask: URLSessionDataTask?
 
-        init(subscriber: AnySubscriber<Output, Error>, callback: @escaping (AnySubscriber<Output, Error>) -> URLSessionDataTask?) {
+        init(subscriber: AnySubscriber<Output, Failure>, callback: @escaping (AnySubscriber<Output, Failure>) -> URLSessionDataTask?) {
             dataTask = callback(subscriber)
         }
 

--- a/Sources/TinyNetworking/Response.swift
+++ b/Sources/TinyNetworking/Response.swift
@@ -10,18 +10,29 @@ import Foundation
 
 public final class Response {
     public let urlRequest: URLRequest
-    public let data: Data
+    public let data: Data?
+    public let httpURLResponse: HTTPURLResponse?
 
-    public init(urlRequest: URLRequest, data: Data) {
+    public init(
+        urlRequest: URLRequest,
+        data: Data?,
+        httpURLResponse: HTTPURLResponse?
+    ) {
         self.urlRequest = urlRequest
         self.data = data
+        self.httpURLResponse = httpURLResponse
     }
 
-    public func map<D>(to type: D.Type) throws -> D where D : Decodable {
+    public func map<D: Decodable>(
+        to type: D.Type,
+        decoder: JSONDecoder = JSONDecoder()
+    ) throws -> D {
+        guard let data = data else { throw TinyNetworkingError.noData(self) }
+
         do {
-            return try JSONDecoder().decode(type, from: data)
+            return try decoder.decode(type, from: data)
         } catch(let error) {
-            throw TinyNetworkingError.decoding(error)
+            throw TinyNetworkingError.decoding(error, self)
         }
     }
 }

--- a/Sources/TinyNetworking/Response.swift
+++ b/Sources/TinyNetworking/Response.swift
@@ -8,10 +8,22 @@
 
 import Foundation
 
-public final class Response {
+public final class Response: CustomDebugStringConvertible {
     public let urlRequest: URLRequest
     public let data: Data?
     public let httpURLResponse: HTTPURLResponse?
+
+    public var description: String {
+        return """
+        Requested URL: \(urlRequest.url?.absoluteString ?? "nil"),
+        Status Code: \(httpURLResponse?.statusCode ?? -999),
+        Data Count: \(data?.count ?? -999)
+        """
+    }
+
+    public var debugDescription: String {
+        return description
+    }
 
     public init(
         urlRequest: URLRequest,
@@ -34,6 +46,21 @@ public final class Response {
         } catch(let error) {
             throw TinyNetworkingError.decoding(error, self)
         }
+    }
+}
+
+private extension Data {
+    var prettyJSONString: NSString? {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: self, options: []),
+            let prettyPrintedData = try? JSONSerialization.data(withJSONObject: object, options: .prettyPrinted)
+            else { return nil }
+
+        return NSString(data: prettyPrintedData, encoding: String.Encoding.utf8.rawValue)
+    }
+
+    var json: Any? {
+        return try? JSONSerialization.jsonObject(with: self, options: .allowFragments)
     }
 }
 

--- a/Sources/TinyNetworking/Response.swift
+++ b/Sources/TinyNetworking/Response.swift
@@ -21,7 +21,7 @@ public final class Response {
         do {
             return try JSONDecoder().decode(type, from: data)
         } catch(let error) {
-            throw Error.decodingFailed(error)
+            throw TinyNetworkingError.decoding(error)
         }
     }
 }

--- a/Sources/TinyNetworking/Response.swift
+++ b/Sources/TinyNetworking/Response.swift
@@ -25,6 +25,14 @@ public final class Response: CustomDebugStringConvertible {
         return description
     }
 
+    public var prettyJSONString: NSString? {
+        return data?.prettyJSONString
+    }
+
+    public var json: Any? {
+        return data?.json
+    }
+
     public init(
         urlRequest: URLRequest,
         data: Data?,

--- a/Sources/TinyNetworking/TinyNetworking.swift
+++ b/Sources/TinyNetworking/TinyNetworking.swift
@@ -21,22 +21,17 @@ public class TinyNetworking<R: Resource>: TinyNetworkingType {
         completion: @escaping (Result<Response, TinyNetworkingError>) -> Void
         ) -> URLSessionDataTask {
         let request = URLRequest(resource: resource)
-        return session.loadData(with: request, queue: queue) { data, httpURLResponse, error in
-            guard error == nil else {
-                completion(.failure(.underlying(error)))
-                return
-            }
-            guard let data = data else {
-                completion(.failure(.noData))
+        return session.loadData(with: request, queue: queue) { response, error in
+            if let error = error { 
+                completion(.failure(.underlying(error, response)))
                 return
             }
 
-            let response = Response(urlRequest: request, data: data)
-
-            guard let httpURLResponse = httpURLResponse as? HTTPURLResponse,
+            guard
+                let httpURLResponse = response.httpURLResponse,
                 200..<300 ~= httpURLResponse.statusCode else {
-                    completion(.failure(.statusCode(response)))
-                    return
+                completion(.failure(.statusCode(response)))
+                return
             }
 
             completion(.success(response))

--- a/Sources/TinyNetworking/TinyNetworking.swift
+++ b/Sources/TinyNetworking/TinyNetworking.swift
@@ -9,14 +9,6 @@
 import Foundation
 import Combine
 
-public enum Error: Swift.Error {
-    case error(Swift.Error?)
-    case emptyResult
-    case decodingFailed(Swift.Error?)
-    case noHttpResponse
-    case requestFailed(Data)
-}
-
 public class TinyNetworking<R: Resource>: TinyNetworkingType {
 
     public init() {}
@@ -26,28 +18,28 @@ public class TinyNetworking<R: Resource>: TinyNetworkingType {
         resource: R,
         session: TinyNetworkingSession = URLSession.shared,
         queue: DispatchQueue = .main,
-        completion: @escaping (Result<Response, Error>) -> Void
+        completion: @escaping (Result<Response, TinyNetworkingError>) -> Void
         ) -> URLSessionDataTask {
         let request = URLRequest(resource: resource)
-        return session.loadData(with: request, queue: queue) { data, response, error in
+        return session.loadData(with: request, queue: queue) { data, httpURLResponse, error in
             guard error == nil else {
-                completion(.failure(.error(error)))
+                completion(.failure(.underlying(error)))
                 return
             }
             guard let data = data else {
-                completion(.failure(.emptyResult))
-                return
-            }
-            guard let response = response as? HTTPURLResponse else {
-                completion(.failure(.noHttpResponse))
-                return
-            }
-            guard 200..<300 ~= response.statusCode else {
-                completion(.failure(.requestFailed(data)))
+                completion(.failure(.noData))
                 return
             }
 
-            completion(.success(Response(urlRequest: request, data: data)))
+            let response = Response(urlRequest: request, data: data)
+
+            guard let httpURLResponse = httpURLResponse as? HTTPURLResponse,
+                200..<300 ~= httpURLResponse.statusCode else {
+                    completion(.failure(.statusCode(response)))
+                    return
+            }
+
+            completion(.success(response))
         }
     }
 }

--- a/Sources/TinyNetworking/TinyNetworkingError.swift
+++ b/Sources/TinyNetworking/TinyNetworkingError.swift
@@ -9,10 +9,25 @@
 import Foundation
 
 public enum TinyNetworkingError: Swift.Error {
-    case noData
+    case noData(Response)
     case statusCode(Response)
-    case decoding(Swift.Error?)
-    case underlying(Swift.Error?)
+    case decoding(Swift.Error, Response)
+    case underlying(Swift.Error, Response?)
+}
+
+public extension TinyNetworkingError {
+    var response: Response? {
+        switch self {
+        case let .noData(response):
+            return response
+        case let .statusCode(response):
+            return response
+        case let .decoding(_, response):
+            return response
+        case let .underlying(_, response):
+            return response
+        }
+    }
 }
 
 extension TinyNetworkingError: LocalizedError {
@@ -24,8 +39,8 @@ extension TinyNetworkingError: LocalizedError {
             return "Status code didn't fall within the given range."
         case .decoding:
             return "Failed to map data to a Decodable object."
-        case let .underlying(error):
-            return error?.localizedDescription
+        case let .underlying(error, _):
+            return error.localizedDescription
         }
     }
 }

--- a/Sources/TinyNetworking/TinyNetworkingError.swift
+++ b/Sources/TinyNetworking/TinyNetworkingError.swift
@@ -1,0 +1,31 @@
+//
+//  TinyNetworkingError.swift
+//  TinyNetworking
+//
+//  Created by Joan Disho on 12.09.19.
+//  Copyright © 2019 Joan Disho. All rights reserved.
+//
+
+import Foundation
+
+public enum TinyNetworkingError: Swift.Error {
+    case noData
+    case statusCode(Response)
+    case decoding(Swift.Error?)
+    case underlying(Swift.Error?)
+}
+
+extension TinyNetworkingError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .noData:
+            return "The request gave no data."
+        case .statusCode:
+            return "Status code didn't fall within the given range."
+        case .decoding:
+            return "Failed to map data to a Decodable object."
+        case let .underlying(error):
+            return error?.localizedDescription
+        }
+    }
+}

--- a/Sources/TinyNetworking/TinyNetworkingType.swift
+++ b/Sources/TinyNetworking/TinyNetworkingType.swift
@@ -16,7 +16,7 @@ public protocol TinyNetworkingType {
         resource: Resource,
         session: TinyNetworkingSession,
         queue: DispatchQueue,
-        completion: @escaping (Result<Response, Error>) -> Void
+        completion: @escaping (Result<Response, TinyNetworkingError>) -> Void
         ) -> URLSessionDataTask
 }
 

--- a/Sources/TinyNetworking/URLSession+Extentions.swift
+++ b/Sources/TinyNetworking/URLSession+Extentions.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol TinyNetworkingSession {
-    typealias CompletionHandler = (Data?, URLResponse?, Swift.Error?) -> Void
+    typealias CompletionHandler = (Response, Swift.Error?) -> Void
     func loadData(
         with urlRequest: URLRequest,
         queue: DispatchQueue,
@@ -21,10 +21,17 @@ extension URLSession: TinyNetworkingSession {
     public func loadData(
         with urlRequest: URLRequest,
         queue: DispatchQueue,
-        completionHandler: @escaping (Data?, URLResponse?, Swift.Error?) -> Void
+        completionHandler: @escaping (Response, Swift.Error?) -> Void
         ) -> URLSessionDataTask {
         let task = dataTask(with: urlRequest) { data, urlResponse, error in
-            queue.async { completionHandler(data, urlResponse, error) }
+            queue.async {
+                let response = Response(
+                    urlRequest: urlRequest,
+                    data: data,
+                    httpURLResponse: urlResponse as? HTTPURLResponse
+                )
+                completionHandler(response, error)
+            }
         }
         task.resume()
         return task

--- a/TinyNetworking.xcodeproj/project.pbxproj
+++ b/TinyNetworking.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3C04F53947782F8F044C63EE /* Pods_TinyNetworking_RxTinyNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9864C1C8F2DF90B71F954ACE /* Pods_TinyNetworking_RxTinyNetworking.framework */; };
+		C0A67853232A42BE004BD891 /* TinyNetworkingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A67852232A42BE004BD891 /* TinyNetworkingError.swift */; };
 		DC22B6112079483400CEB596 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC927ACB2070427000B5915E /* Task.swift */; };
 		DC22B6122079483400CEB596 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC320FE0204BFD8E0055A938 /* Endpoint.swift */; };
 		DC22B6132079483400CEB596 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC927ACD2070427800B5915E /* AnyEncodable.swift */; };
@@ -55,6 +56,7 @@
 		8929E43197EB788743E9F8E1 /* Pods-TinyNetworking-RxTinyNetworking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TinyNetworking-RxTinyNetworking.release.xcconfig"; path = "Pods/Target Support Files/Pods-TinyNetworking-RxTinyNetworking/Pods-TinyNetworking-RxTinyNetworking.release.xcconfig"; sourceTree = "<group>"; };
 		9864C1C8F2DF90B71F954ACE /* Pods_TinyNetworking_RxTinyNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TinyNetworking_RxTinyNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B0BB9B959956EB7D07FB5338 /* Pods_TinyNetworkingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TinyNetworkingTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0A67852232A42BE004BD891 /* TinyNetworkingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TinyNetworkingError.swift; sourceTree = "<group>"; };
 		C7B6D6B7EB694FA340950D07 /* Pods_TinyNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TinyNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC22B61A20794AF600CEB596 /* URLSession+Extentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extentions.swift"; sourceTree = "<group>"; };
 		DC320FC6204BFD760055A938 /* TinyNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TinyNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -160,6 +162,7 @@
 			children = (
 				DC3E26F723204A4F00DB55EA /* Combine */,
 				DC927ACB2070427000B5915E /* Task.swift */,
+				C0A67852232A42BE004BD891 /* TinyNetworkingError.swift */,
 				DC320FE0204BFD8E0055A938 /* Endpoint.swift */,
 				DC927ACD2070427800B5915E /* AnyEncodable.swift */,
 				DC927AD12070428C00B5915E /* Response.swift */,
@@ -408,6 +411,7 @@
 				DCAED62421A7537C007BDE95 /* URLEncoding.swift in Sources */,
 				DCFD07D5206D7076001F0C35 /* TinyNetworkingType.swift in Sources */,
 				DC927AD02070428400B5915E /* ResourceType.swift in Sources */,
+				C0A67853232A42BE004BD891 /* TinyNetworkingError.swift in Sources */,
 				DC22B61B20794AF600CEB596 /* URLSession+Extentions.swift in Sources */,
 				DC320FE4204BFD8E0055A938 /* Endpoint.swift in Sources */,
 				DC927AD22070428C00B5915E /* Response.swift in Sources */,


### PR DESCRIPTION
- Rename `Error` to `TinyNetworkingError` (Avoid confusion with `Swift.Error`).
- Cover `.noHTTPResponse` error case into `.statusCode`.
- The `completionHandler` of `loadData(with:queue:completionHandler:)` to gives a `response: Response` instead of `data: Data?` and `response: URLResponse`.

#### Debugging
- Include `Response` in each error case.
- Add `HTTPURLResponse` in `Response`.
- Provide a custom description to `Response`.
- Provide an error description and response for each error case.
- Get the `JSON` from the `Response` as `Any?` or as a prettified string. 